### PR TITLE
trim id - some ids coming in with left padding

### DIFF
--- a/src/main/java/org/killbill/billing/plugin/adyen/client/model/PaymentServiceProviderResult.java
+++ b/src/main/java/org/killbill/billing/plugin/adyen/client/model/PaymentServiceProviderResult.java
@@ -60,12 +60,14 @@ public enum PaymentServiceProviderResult {
             return ERROR;
         }
 
-        final PaymentServiceProviderResult result = REVERSE_LOOKUP.get(id);
+        String trimmedId = id.trim();
+
+        final PaymentServiceProviderResult result = REVERSE_LOOKUP.get(trimmedId);
         if (result != null) {
             return result;
         } else {
             // For HPP completion flow (see https://docs.adyen.com/developers/hpp-manual#hpppaymentresponse)
-            return PaymentServiceProviderResult.valueOf(id);
+            return PaymentServiceProviderResult.valueOf(trimmedId);
         }
     }
 

--- a/src/test/java/org/killbill/billing/plugin/adyen/client/model/TestPaymentServiceProviderResult.java
+++ b/src/test/java/org/killbill/billing/plugin/adyen/client/model/TestPaymentServiceProviderResult.java
@@ -36,5 +36,8 @@ public class TestPaymentServiceProviderResult {
         Assert.assertEquals(PaymentServiceProviderResult.getPaymentResultForId("CANCELLED"), PaymentServiceProviderResult.CANCELLED);
         Assert.assertEquals(PaymentServiceProviderResult.getPaymentResultForId("PENDING"), PaymentServiceProviderResult.PENDING);
         Assert.assertEquals(PaymentServiceProviderResult.getPaymentResultForId("ERROR"), PaymentServiceProviderResult.ERROR);
+
+        Assert.assertEquals(PaymentServiceProviderResult.getPaymentResultForId("[refund-received]   "), PaymentServiceProviderResult.RECEIVED);
+
     }
 }


### PR DESCRIPTION
In testing, some id values provided by Adyen were right padded.   This defeated the REVERSE_LOOKUP and caused the valueOf function to puke.